### PR TITLE
Bump html-pipeline dependency?

### DIFF
--- a/html-pipeline-asciidoc_filter.gemspec
+++ b/html-pipeline-asciidoc_filter.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(/^test\//)
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'html-pipeline', '~> 1.11.0'
+  gem.add_dependency 'html-pipeline', '~> 2.2'
   gem.add_dependency 'asciidoctor', '~> 1.5.2'
 end


### PR DESCRIPTION
Version 2.x has been out for a while, so I wonder if there's interest in bumping this. 
